### PR TITLE
Add exact cached dense reconstruction path and benchmarks

### DIFF
--- a/benchmarks/benchmark_reconstruction_subset.py
+++ b/benchmarks/benchmark_reconstruction_subset.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_baseline_iA(A_vxm: np.ndarray, lambda1: float, lambda2: float):
+    A = A_vxm.T.astype(np.float64, copy=False)
+    ll = None
+    if lambda2:
+        ll0 = np.sum(A**2, axis=0, dtype=np.float64)
+        ll = np.sqrt(ll0 + lambda2 * np.max(ll0))
+        A = A / ll
+
+    att = A @ A.T
+    ss = np.linalg.norm(att)
+    penalty = float(np.sqrt(ss) * lambda1)
+    iatt = np.linalg.inv(att + (penalty**2) * np.eye(att.shape[0], dtype=np.float64))
+    iA = A.T @ iatt
+    if ll is not None:
+        iA = iA / ll[:, None]
+    return iA * (1 / 100)
+
+
+def timed(fn, *args, **kwargs):
+    t0 = time.perf_counter()
+    out = fn(*args, **kwargs)
+    dt = time.perf_counter() - t0
+    return out, dt
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("subset_npz", type=Path)
+    parser.add_argument("reconstruction_py", type=Path)
+    parser.add_argument("reconstruction_cached_py", type=Path)
+    parser.add_argument("--lambda1", type=float, default=0.01)
+    parser.add_argument("--lambda2", type=float, default=0.1)
+    parser.add_argument("--gsigma", type=float, default=3.0)
+    parser.add_argument("--timepoints", type=int, default=20)
+    args = parser.parse_args()
+
+    recon = load_module("bench_recon", args.reconstruction_py)
+    cached = load_module("bench_recon_cached", args.reconstruction_cached_py)
+
+    data = np.load(args.subset_npz, allow_pickle=False)
+    A_vxm = data["A_vxm"]
+    good_vox = data["Good_Vox"]
+    dim = {
+        "nVx": int(data["nVx"][0]),
+        "nVy": int(data["nVy"][0]),
+        "nVz": int(data["nVz"][0]),
+        "sV": float(data["sV"][0]),
+        "Good_Vox": good_vox,
+    }
+
+    rng = np.random.default_rng(42)
+    y = rng.normal(size=(A_vxm.shape[1], args.timepoints))
+
+    baseline_iA, baseline_build_iA_s = timed(
+        build_baseline_iA, A_vxm, args.lambda1, args.lambda2
+    )
+    baseline_smooth, baseline_smooth_s = timed(
+        recon.smooth_Amat,
+        baseline_iA,
+        dim,
+        args.gsigma,
+    )
+    baseline_final, baseline_apply_s = timed(np.matmul, baseline_smooth, y)
+
+    cache, improved_build_s = timed(
+        cached.build_tikhonov_cache_vox_by_meas,
+        A_vxm,
+        args.lambda1,
+        args.lambda2,
+        None,
+        4096,
+    )
+    improved_img, improved_recon_s = timed(
+        cached.reconstruct_img_from_cache_vox_by_meas,
+        y,
+        A_vxm,
+        cache,
+    )
+    improved_smooth, improved_smooth_s = timed(
+        cached.smooth_img_vox, improved_img, dim, args.gsigma
+    )
+
+    cached_img, cached_recon_s = timed(
+        cached.reconstruct_img_from_cache_vox_by_meas,
+        y,
+        A_vxm,
+        cache,
+    )
+    cached_smooth, cached_smooth_s = timed(
+        cached.smooth_img_vox, cached_img, dim, args.gsigma
+    )
+
+    result = {
+        "subset_shape": [int(A_vxm.shape[0]), int(A_vxm.shape[1])],
+        "timepoints": args.timepoints,
+        "lambda1": args.lambda1,
+        "lambda2": args.lambda2,
+        "gsigma": args.gsigma,
+        "baseline_build_iA_s": baseline_build_iA_s,
+        "baseline_smooth_s": baseline_smooth_s,
+        "baseline_apply_s": baseline_apply_s,
+        "baseline_total_s": baseline_build_iA_s + baseline_smooth_s + baseline_apply_s,
+        "improved_build_cache_s": improved_build_s,
+        "improved_recon_s": improved_recon_s,
+        "improved_smooth_s": improved_smooth_s,
+        "improved_first_total_s": improved_build_s + improved_recon_s + improved_smooth_s,
+        "improved_cached_recon_s": cached_recon_s,
+        "improved_cached_smooth_s": cached_smooth_s,
+        "improved_cached_total_s": cached_recon_s + cached_smooth_s,
+        "baseline_vs_improved_max_abs_err": float(np.max(np.abs(baseline_final - improved_smooth))),
+        "improved_repeat_max_abs_err": float(np.max(np.abs(improved_smooth - cached_smooth))),
+        "speedup_first_run_vs_baseline": float(
+            (baseline_build_iA_s + baseline_smooth_s + baseline_apply_s)
+            / (improved_build_s + improved_recon_s + improved_smooth_s)
+        ),
+        "speedup_cached_vs_baseline": float(
+            (baseline_build_iA_s + baseline_smooth_s + baseline_apply_s)
+            / (cached_recon_s + cached_smooth_s)
+        ),
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_report_2026-03-27.md
+++ b/benchmarks/benchmark_report_2026-03-27.md
@@ -1,0 +1,109 @@
+# NeuroDOT Reconstruction Benchmark Report
+
+Date: 2026-03-27
+
+This note compares the current explicit-`iA` reconstruction path against the
+new exact dense cached reconstruction strategy on real subsets extracted from:
+
+`/Users/amit/Downloads/A_Adult_96x92.mat`
+
+Both paths preserve the same math:
+
+- same `A`
+- same `lambda1`
+- same `lambda2`
+- same Gaussian smoothing kernel
+
+The only change is execution strategy:
+
+- baseline: explicitly build `iA`, smooth `iA`, then apply it
+- improved: build a measurement-space cache, reconstruct without materializing
+  `iA`, then smooth the reconstructed image
+
+## Benchmark Harness
+
+Files:
+
+- `benchmarks/benchmark_reconstruction_subset.py`
+- `benchmarks/reconstruction_standalone.py`
+- `benchmarks/reconstruction_cached_standalone.py`
+
+Subset files used for the measurements were generated locally from the NITRC
+matrix and were not committed.
+
+Common parameters:
+
+- `lambda1 = 0.01`
+- `lambda2 = 0.1`
+- `gsigma = 3`
+- `timepoints = 20`
+
+## Commands
+
+Local:
+
+```bash
+python3 benchmarks/benchmark_reconstruction_subset.py \
+  benchmarks/A_Adult_96x92_subset_m128.npz \
+  benchmarks/reconstruction_standalone.py \
+  benchmarks/reconstruction_cached_standalone.py \
+  --lambda1 0.01 --lambda2 0.1 --gsigma 3 --timepoints 20
+
+python3 benchmarks/benchmark_reconstruction_subset.py \
+  benchmarks/A_Adult_96x92_subset_m256.npz \
+  benchmarks/reconstruction_standalone.py \
+  benchmarks/reconstruction_cached_standalone.py \
+  --lambda1 0.01 --lambda2 0.1 --gsigma 3 --timepoints 20
+```
+
+br200:
+
+```bash
+ssh br200 "cd /N/u/atsubhas/NeuroDOT_bench_2026-03-27 && \
+python3 benchmark_reconstruction_subset.py \
+  A_Adult_96x92_subset_m128.npz \
+  reconstruction_standalone.py \
+  reconstruction_cached_standalone.py \
+  --lambda1 0.01 --lambda2 0.1 --gsigma 3 --timepoints 20"
+
+ssh br200 "cd /N/u/atsubhas/NeuroDOT_bench_2026-03-27 && \
+python3 benchmark_reconstruction_subset.py \
+  A_Adult_96x92_subset_m256.npz \
+  reconstruction_standalone.py \
+  reconstruction_cached_standalone.py \
+  --lambda1 0.01 --lambda2 0.1 --gsigma 3 --timepoints 20"
+```
+
+## Results
+
+### Local Mac
+
+| Subset | Baseline Total | Improved First Run | Improved Cached Rerun | First-Run Speedup | Cached Speedup | Max Abs Error |
+|---|---:|---:|---:|---:|---:|---:|
+| `156461 x 128` | `0.578 s` | `0.157 s` | `0.108 s` | `3.67x` | `5.36x` | `1.90e-15` |
+| `156461 x 256` | `1.295 s` | `0.261 s` | `0.132 s` | `4.96x` | `9.81x` | `2.28e-15` |
+
+### br200
+
+| Subset | Baseline Total | Improved First Run | Improved Cached Rerun | First-Run Speedup | Cached Speedup | Max Abs Error |
+|---|---:|---:|---:|---:|---:|---:|
+| `156461 x 128` | `7.079 s` | `1.078 s` | `0.392 s` | `6.56x` | `18.04x` | `1.76e-16` |
+| `156461 x 256` | `14.393 s` | `1.581 s` | `0.623 s` | `9.10x` | `23.10x` | `2.57e-16` |
+
+## Observations
+
+- The improved path is numerically aligned with the baseline to machine
+  precision on these benchmarks.
+- The speedup increases with measurement count, which is what we want.
+- The biggest gain comes from avoiding explicit `iA` construction and from
+  smoothing the reconstructed image instead of smoothing all columns of `iA`.
+- Cached reruns are materially faster than first runs because the
+  measurement-space factorization is reused.
+
+## Practical Interpretation
+
+- The exact dense cached strategy is not just theoretically better. It is
+  already significantly faster on real subsets from the actual NITRC matrix.
+- On `br200`, the larger `m256` subset shows about `9.1x` first-run speedup
+  and about `23.1x` cached-rerun speedup.
+- This makes the approach worth integrating into the real NeuroDOT pipeline.

--- a/benchmarks/reconstruction_cached_standalone.py
+++ b/benchmarks/reconstruction_cached_standalone.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+import scipy.linalg as spla
+import scipy.ndimage as ndi
+
+
+@dataclass
+class TikhonovCache:
+    cho: tuple[np.ndarray, bool]
+    keep_idx: np.ndarray
+    lambda1: float
+    lambda2: float
+    penalty: float
+    ll: Optional[np.ndarray]
+    gram: np.ndarray
+    block_rows: int
+
+
+def _normalize_keep(measurement_count: int, keep: Optional[np.ndarray]) -> np.ndarray:
+    if keep is None:
+        return np.arange(measurement_count, dtype=np.int64)
+
+    keep_arr = np.asarray(keep)
+    if keep_arr.dtype == np.bool_:
+        return np.flatnonzero(keep_arr)
+    keep_idx = np.asarray(keep_arr, dtype=np.int64).reshape(-1)
+    return np.unique(keep_idx)
+
+
+def _iter_voxel_blocks(A_vxm: Any, keep_idx: np.ndarray, block_rows: int):
+    voxel_count = int(A_vxm.shape[0])
+    for start in range(0, voxel_count, block_rows):
+        stop = min(start + block_rows, voxel_count)
+        yield start, stop, np.asarray(A_vxm[start:stop, keep_idx], dtype=np.float64)
+
+
+def compute_svr_weights_vox_by_meas(
+    A_vxm: Any,
+    keep: Optional[np.ndarray] = None,
+    lambda2: float = 0.0,
+    block_rows: int = 2048,
+) -> Optional[np.ndarray]:
+    if not lambda2:
+        return None
+
+    keep_idx = _normalize_keep(int(A_vxm.shape[1]), keep)
+    ll_0 = np.empty(int(A_vxm.shape[0]), dtype=np.float64)
+    for start, stop, block in _iter_voxel_blocks(A_vxm, keep_idx, block_rows):
+        ll_0[start:stop] = np.sum(block * block, axis=1, dtype=np.float64)
+    ll = np.sqrt(ll_0 + float(lambda2) * float(np.max(ll_0)))
+    ll[ll == 0] = 1.0
+    return ll
+
+
+def build_measurement_gram_vox_by_meas(
+    A_vxm: Any,
+    keep: Optional[np.ndarray] = None,
+    lambda2: float = 0.0,
+    block_rows: int = 2048,
+):
+    measurement_count = int(A_vxm.shape[1])
+    keep_idx = _normalize_keep(measurement_count, keep)
+    ll = compute_svr_weights_vox_by_meas(A_vxm, keep=keep_idx, lambda2=lambda2, block_rows=block_rows)
+    gram = np.zeros((keep_idx.size, keep_idx.size), dtype=np.float64)
+    for start, stop, block in _iter_voxel_blocks(A_vxm, keep_idx, block_rows):
+        if ll is not None:
+            block = block / ll[start:stop, None]
+        gram += block.T @ block
+    return gram, ll, keep_idx
+
+
+def build_tikhonov_cache_vox_by_meas(
+    A_vxm: Any,
+    lambda1: float,
+    lambda2: float = 0.0,
+    keep: Optional[np.ndarray] = None,
+    block_rows: int = 2048,
+) -> TikhonovCache:
+    gram, ll, keep_idx = build_measurement_gram_vox_by_meas(
+        A_vxm,
+        keep=keep,
+        lambda2=lambda2,
+        block_rows=block_rows,
+    )
+    ss = np.linalg.norm(gram)
+    penalty = float(np.sqrt(ss) * float(lambda1))
+    regularized = gram + (penalty**2) * np.eye(gram.shape[0], dtype=np.float64)
+    cho = spla.cho_factor(regularized, overwrite_a=False, check_finite=False)
+    return TikhonovCache(cho, keep_idx, float(lambda1), float(lambda2), penalty, ll, gram, int(block_rows))
+
+
+def reconstruct_img_from_cache_vox_by_meas(
+    lmdata: np.ndarray,
+    A_vxm: Any,
+    cache: TikhonovCache,
+    units_scaling: float = 1 / 100,
+) -> np.ndarray:
+    y = np.asarray(lmdata, dtype=np.float64)
+    if y.ndim == 1:
+        y = y[:, None]
+
+    z = spla.cho_solve(cache.cho, y, check_finite=False)
+    voxel_count = int(A_vxm.shape[0])
+    img = np.zeros((voxel_count, y.shape[1]), dtype=np.float64)
+
+    for start, stop, block in _iter_voxel_blocks(A_vxm, cache.keep_idx, cache.block_rows):
+        if cache.ll is not None:
+            block = block / cache.ll[start:stop, None]
+        img_block = block @ z
+        if cache.ll is not None:
+            img_block = img_block / cache.ll[start:stop, None]
+        img[start:stop, :] = img_block
+
+    return img * float(units_scaling)
+
+
+def smooth_img_vox(img_in: np.ndarray, dim: dict, gsigma: float) -> np.ndarray:
+    img = np.asarray(img_in, dtype=np.float64)
+    if img.ndim == 1:
+        img = img[:, None]
+
+    nVx = int(dim["nVx"])
+    nVy = int(dim["nVy"])
+    nVz = int(dim["nVz"])
+    sigma = float(gsigma) / float(dim["sV"])
+    gv = np.asarray(dim["Good_Vox"], dtype=np.int64).reshape(-1) - 1
+
+    smoothed = np.zeros_like(img)
+    for t in range(img.shape[1]):
+        vol = np.zeros(nVx * nVy * nVz, dtype=np.float64)
+        vol[gv] = img[:, t]
+        vol = np.reshape(vol, (nVx, nVy, nVz), order="F")
+        vol = ndi.gaussian_filter(
+            vol,
+            sigma,
+            mode="nearest",
+            truncate=np.ceil(2 * sigma) / sigma,
+        )
+        smoothed[:, t] = np.reshape(vol, (-1,), order="F")[gv]
+    return smoothed

--- a/benchmarks/reconstruction_standalone.py
+++ b/benchmarks/reconstruction_standalone.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+import scipy.ndimage as ndi
+
+
+def smooth_Amat(iA_in, dim, gsigma):
+    nvox = np.shape(iA_in)[0]
+    nm = np.shape(iA_in)[1]
+    iA_out = np.zeros((nvox, nm), dtype=np.float64)
+
+    nVx = int(dim["nVx"])
+    nVy = int(dim["nVy"])
+    nVz = int(dim["nVz"])
+    gsigma = gsigma / dim["sV"]
+
+    if "Good_Vox" in dim:
+        gv = np.asarray(dim["Good_Vox"], dtype=np.int64).reshape(-1)
+    else:
+        gv = np.arange(1, nVx * nVy * nVz + 1, dtype=np.int64)
+
+    for k in range(nm):
+        iAvox = np.zeros((nVx * nVy * nVz,), dtype=np.float64)
+        iAvox[gv - 1] = iA_in[:, k]
+        iAvox = np.reshape(iAvox, (nVx, nVy, nVz), order="F")
+        iAvox = ndi.gaussian_filter(
+            iAvox,
+            gsigma,
+            mode="nearest",
+            truncate=np.ceil(2 * gsigma) / gsigma,
+        )
+        iA_out[:, k] = np.reshape(iAvox, (-1,), order="F")[gv - 1]
+
+    return iA_out

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ deepdiff
 matplotlib
 numpy
 scipy
+h5py
 sympy
 keyboard
 plotly

--- a/src/neuro_dot/Reconstruction_Cached.py
+++ b/src/neuro_dot/Reconstruction_Cached.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import scipy.linalg as spla
+import scipy.ndimage as ndi
+
+
+@dataclass
+class TikhonovCache:
+    """Cached measurement-space solve state for an exact dense reconstruction."""
+
+    cho: tuple[np.ndarray, bool]
+    keep_idx: np.ndarray
+    lambda1: float
+    lambda2: float
+    penalty: float
+    ll: Optional[np.ndarray]
+    gram: np.ndarray
+    block_rows: int
+    dtype: np.dtype
+
+
+def _normalize_keep(
+    measurement_count: int, keep: Optional[np.ndarray]
+) -> np.ndarray:
+    if keep is None:
+        return np.arange(measurement_count, dtype=np.int64)
+
+    keep_arr = np.asarray(keep)
+    if keep_arr.dtype == np.bool_:
+        if keep_arr.ndim != 1 or keep_arr.shape[0] != measurement_count:
+            raise ValueError("Boolean keep mask must match measurement count.")
+        return np.flatnonzero(keep_arr)
+
+    keep_idx = np.asarray(keep_arr, dtype=np.int64).reshape(-1)
+    if keep_idx.size == 0:
+        raise ValueError("Keep mask produced no measurements.")
+    if np.any(keep_idx < 0) or np.any(keep_idx >= measurement_count):
+        raise ValueError("Keep indices are out of bounds.")
+    return np.unique(keep_idx)
+
+
+def _iter_voxel_blocks(
+    A_vxm: Any, keep_idx: np.ndarray, block_rows: int
+):
+    voxel_count = int(A_vxm.shape[0])
+    for start in range(0, voxel_count, block_rows):
+        stop = min(start + block_rows, voxel_count)
+        block = np.asarray(A_vxm[start:stop, keep_idx], dtype=np.float64)
+        yield start, stop, block
+
+
+def compute_svr_weights_vox_by_meas(
+    A_vxm: Any,
+    keep: Optional[np.ndarray] = None,
+    lambda2: float = 0.0,
+    block_rows: int = 2048,
+) -> Optional[np.ndarray]:
+    """
+    Compute the exact NeuroDOT spatially variant regularization weights.
+    """
+    if not lambda2:
+        return None
+
+    keep_idx = _normalize_keep(int(A_vxm.shape[1]), keep)
+    ll_0 = np.empty(int(A_vxm.shape[0]), dtype=np.float64)
+
+    for start, stop, block in _iter_voxel_blocks(A_vxm, keep_idx, block_rows):
+        ll_0[start:stop] = np.sum(block * block, axis=1, dtype=np.float64)
+
+    ll = np.sqrt(ll_0 + float(lambda2) * float(np.max(ll_0)))
+    ll[ll == 0] = 1.0
+    return ll
+
+
+def build_measurement_gram_vox_by_meas(
+    A_vxm: Any,
+    keep: Optional[np.ndarray] = None,
+    lambda2: float = 0.0,
+    block_rows: int = 2048,
+    ll: Optional[np.ndarray] = None,
+) -> tuple[np.ndarray, Optional[np.ndarray], np.ndarray]:
+    """
+    Build the exact measurement-space Gram matrix for a dense voxel x measurement A.
+    """
+    measurement_count = int(A_vxm.shape[1])
+    keep_idx = _normalize_keep(measurement_count, keep)
+    ll_vec = ll
+    if lambda2 and ll_vec is None:
+        ll_vec = compute_svr_weights_vox_by_meas(
+            A_vxm, keep=keep_idx, lambda2=lambda2, block_rows=block_rows
+        )
+
+    gram = np.zeros((keep_idx.size, keep_idx.size), dtype=np.float64)
+    for start, stop, block in _iter_voxel_blocks(A_vxm, keep_idx, block_rows):
+        if ll_vec is not None:
+            block = block / ll_vec[start:stop, None]
+        gram += block.T @ block
+
+    return gram, ll_vec, keep_idx
+
+
+def subset_measurement_gram(
+    full_gram: np.ndarray, keep: Optional[np.ndarray]
+) -> tuple[np.ndarray, np.ndarray]:
+    keep_idx = _normalize_keep(int(full_gram.shape[0]), keep)
+    return full_gram[np.ix_(keep_idx, keep_idx)], keep_idx
+
+
+def factorize_tikhonov_gram(
+    gram: np.ndarray,
+    lambda1: float,
+) -> tuple[tuple[np.ndarray, bool], float]:
+    """
+    Factor the NeuroDOT measurement-space Tikhonov system.
+    """
+    if gram.ndim != 2 or gram.shape[0] != gram.shape[1]:
+        raise ValueError("Gram matrix must be square.")
+
+    ss = np.linalg.norm(gram)
+    penalty = float(np.sqrt(ss) * float(lambda1))
+    regularized = gram + (penalty**2) * np.eye(gram.shape[0], dtype=np.float64)
+    return spla.cho_factor(regularized, overwrite_a=False, check_finite=False), penalty
+
+
+def build_tikhonov_cache_vox_by_meas(
+    A_vxm: Any,
+    lambda1: float,
+    lambda2: float = 0.0,
+    keep: Optional[np.ndarray] = None,
+    block_rows: int = 2048,
+    full_gram: Optional[np.ndarray] = None,
+) -> TikhonovCache:
+    """
+    Build an exact cached solve state for dense voxel x measurement A-matrices.
+
+    When lambda2 is zero, callers may pass a precomputed full measurement-space
+    Gram matrix and reuse principal submatrices across keep masks.
+    """
+    if lambda2 and full_gram is not None:
+        raise ValueError("full_gram reuse is only exact when lambda2 == 0.")
+
+    if full_gram is not None:
+        gram, keep_idx = subset_measurement_gram(full_gram, keep)
+        ll = None
+    else:
+        gram, ll, keep_idx = build_measurement_gram_vox_by_meas(
+            A_vxm,
+            keep=keep,
+            lambda2=lambda2,
+            block_rows=block_rows,
+        )
+
+    cho, penalty = factorize_tikhonov_gram(gram, lambda1=lambda1)
+    return TikhonovCache(
+        cho=cho,
+        keep_idx=keep_idx,
+        lambda1=float(lambda1),
+        lambda2=float(lambda2),
+        penalty=penalty,
+        ll=ll,
+        gram=gram,
+        block_rows=int(block_rows),
+        dtype=np.dtype(np.float64),
+    )
+
+
+def build_measurement_gram_from_mat_file(
+    mat_path: str | Path,
+    dataset_name: str = "A",
+    keep: Optional[np.ndarray] = None,
+    lambda2: float = 0.0,
+    block_rows: int = 2048,
+) -> tuple[np.ndarray, Optional[np.ndarray], np.ndarray]:
+    """
+    Open a MATLAB v7.3 file lazily and build an exact measurement-space Gram.
+    """
+    import h5py
+
+    with h5py.File(mat_path, "r") as f:
+        return build_measurement_gram_vox_by_meas(
+            f[dataset_name],
+            keep=keep,
+            lambda2=lambda2,
+            block_rows=block_rows,
+        )
+
+
+def build_tikhonov_cache_from_mat_file(
+    mat_path: str | Path,
+    lambda1: float,
+    lambda2: float = 0.0,
+    keep: Optional[np.ndarray] = None,
+    block_rows: int = 2048,
+    dataset_name: str = "A",
+    full_gram: Optional[np.ndarray] = None,
+) -> TikhonovCache:
+    """
+    Open a MATLAB v7.3 file lazily and build an exact cached solve state.
+    """
+    import h5py
+
+    with h5py.File(mat_path, "r") as f:
+        return build_tikhonov_cache_vox_by_meas(
+            f[dataset_name],
+            lambda1=lambda1,
+            lambda2=lambda2,
+            keep=keep,
+            block_rows=block_rows,
+            full_gram=full_gram,
+        )
+
+
+def reconstruct_img_from_cache_vox_by_meas(
+    lmdata: np.ndarray,
+    A_vxm: Any,
+    cache: TikhonovCache,
+    units_scaling: float = 1 / 100,
+    out_dtype: Any = np.float64,
+) -> np.ndarray:
+    """
+    Reconstruct images without materializing iA.
+    """
+    y = np.asarray(lmdata, dtype=np.float64)
+    if y.ndim == 1:
+        y = y[:, None]
+    if y.shape[0] != cache.keep_idx.size:
+        raise ValueError("lmdata row count must match cached keep mask size.")
+
+    z = spla.cho_solve(cache.cho, y, check_finite=False)
+    voxel_count = int(A_vxm.shape[0])
+    img = np.zeros((voxel_count, y.shape[1]), dtype=np.float64)
+
+    for start, stop, block in _iter_voxel_blocks(
+        A_vxm, cache.keep_idx, cache.block_rows
+    ):
+        if cache.ll is not None:
+            block = block / cache.ll[start:stop, None]
+        img_block = block @ z
+        if cache.ll is not None:
+            img_block = img_block / cache.ll[start:stop, None]
+        img[start:stop, :] = img_block
+
+    img *= float(units_scaling)
+    return np.asarray(img, dtype=out_dtype)
+
+
+def reconstruct_img_from_mat_file(
+    lmdata: np.ndarray,
+    mat_path: str | Path,
+    cache: TikhonovCache,
+    dataset_name: str = "A",
+    units_scaling: float = 1 / 100,
+    out_dtype: Any = np.float64,
+) -> np.ndarray:
+    """
+    Open a MATLAB v7.3 file lazily and reconstruct without materializing iA.
+    """
+    import h5py
+
+    with h5py.File(mat_path, "r") as f:
+        return reconstruct_img_from_cache_vox_by_meas(
+            lmdata,
+            f[dataset_name],
+            cache,
+            units_scaling=units_scaling,
+            out_dtype=out_dtype,
+        )
+
+
+def smooth_img_vox(
+    img_in: np.ndarray,
+    dim: dict,
+    gsigma: float,
+    out_dtype: Any = np.float64,
+) -> np.ndarray:
+    """
+    Apply the same Gaussian voxel-space smoothing to reconstructed images.
+
+    This is the image-space equivalent of smoothing iA before reconstruction.
+    """
+    img = np.asarray(img_in, dtype=np.float64)
+    if img.ndim == 1:
+        img = img[:, None]
+
+    nVx = int(dim["nVx"])
+    nVy = int(dim["nVy"])
+    nVz = int(dim["nVz"])
+    sigma = float(gsigma) / float(dim["sV"])
+
+    if "Good_Vox" in dim:
+        gv = np.asarray(dim["Good_Vox"], dtype=np.int64).reshape(-1) - 1
+    else:
+        gv = np.arange(nVx * nVy * nVz, dtype=np.int64)
+
+    smoothed = np.zeros_like(img)
+    for t in range(img.shape[1]):
+        vol = np.zeros(nVx * nVy * nVz, dtype=np.float64)
+        vol[gv] = img[:, t]
+        vol = np.reshape(vol, (nVx, nVy, nVz), order="F")
+        vol = ndi.gaussian_filter(
+            vol,
+            sigma,
+            mode="nearest",
+            truncate=np.ceil(2 * sigma) / sigma,
+        )
+        smoothed[:, t] = np.reshape(vol, (-1,), order="F")[gv]
+
+    return np.asarray(smoothed, dtype=out_dtype)
+
+
+def save_measurement_gram_cache(
+    cache_path: str | Path,
+    gram: np.ndarray,
+    keep_idx: Optional[np.ndarray] = None,
+    ll: Optional[np.ndarray] = None,
+) -> None:
+    """
+    Persist a measurement-space Gram cache to disk.
+    """
+    payload = {"gram": np.asarray(gram, dtype=np.float64)}
+    if keep_idx is not None:
+        payload["keep_idx"] = np.asarray(keep_idx, dtype=np.int64)
+    if ll is not None:
+        payload["ll"] = np.asarray(ll, dtype=np.float64)
+    np.savez_compressed(cache_path, **payload)
+
+
+def load_measurement_gram_cache(
+    cache_path: str | Path,
+) -> dict[str, np.ndarray]:
+    """
+    Load a measurement-space Gram cache from disk.
+    """
+    with np.load(cache_path, allow_pickle=False) as data:
+        return {key: data[key] for key in data.files}

--- a/src/neuro_dot/__init__.py
+++ b/src/neuro_dot/__init__.py
@@ -6,5 +6,5 @@ from neuro_dot.Matlab_Equivalent_Functions import *
 from neuro_dot.Light_Modeling import *
 from neuro_dot.DynamicFilter import *
 from neuro_dot.Reconstruction import *
+from neuro_dot.Reconstruction_Cached import *
 from neuro_dot.Analysis import *
-


### PR DESCRIPTION
Hello, I'm Amit, a neuroengineering researcher, and I love the work you have
done in this library. I used to use the MATLAB version, but since I got a new
Mac, I wanted to play around with the Python version too. I hope this will be
of help.

## Summary

Add an exact cached dense reconstruction path for large voxel-by-measurement
NeuroDOT A-matrices without materializing the explicit inverse-like `iA`
operator.

This PR is additive:

- keeps the existing `Reconstruction.py` path unchanged
- adds a new `Reconstruction_Cached.py` module
- exports the new helpers from `neuro_dot`
- adds benchmark harnesses and benchmark results

## Motivation

The current reconstruction path builds `iA` explicitly and smooths `iA`
column-by-column. For large NITRC-distributed matrices such as
`A_Adult_96x92.mat`, that approach creates a large memory burden and spends a
significant amount of time in inverse construction and smoothing.

The new path computes the same reconstruction operator in measurement space:

- factorize a regularized measurement-space Gram system
- solve in measurement space
- backproject directly into image space
- apply the same Gaussian smoothing to the reconstructed image instead of to
  every column of `iA`

This preserves the exact dense matrix values. No thresholding or sparse
approximation is used.

## What Changed

- Added [`src/neuro_dot/Reconstruction_Cached.py`](src/neuro_dot/Reconstruction_Cached.py)
  with:
  - exact measurement-space Gram construction for dense voxel x measurement
    matrices
  - exact spatially variant regularization weight computation
  - cached Cholesky factorization for the Tikhonov system
  - lazy MATLAB v7.3 loading through `h5py`
  - reconstruction without materializing `iA`
  - image-space smoothing equivalent to smoothing `iA` first
  - optional save/load helpers for measurement-space Gram caches
- Exported the new module in [`src/neuro_dot/__init__.py`](src/neuro_dot/__init__.py)
- Added `h5py` to [`requirements.txt`](requirements.txt)
- Added benchmark utilities under [`benchmarks/`](benchmarks)

## Exactness Notes

- The new reconstruction path is intended to be mathematically equivalent to
  the explicit-`iA` path up to floating-point roundoff.
- The implementation keeps the solve path in `float64`.
- For `lambda2 == 0`, a full measurement-space Gram cache can be reused
  exactly across changing keep masks by taking principal submatrices.
- For `lambda2 != 0`, exact reuse of a full Gram across arbitrary keep masks is
  not valid because the spatially variant regularization weights depend on the
  kept measurements. In that case the cache is exact per keep mask.

## Validation

### Synthetic Checks

- Exact-match verification against the current explicit formula passed for
  `lambda2 = 0.0` and `lambda2 = 0.1`
- Observed max absolute differences were on the order of `1e-18`
- Smoothing equivalence check passed with max absolute error around `3.4e-08`

### Real A-Matrix Smoke Check

- Verified on subsets extracted from the NITRC `A_Adult_96x92.mat` matrix
- Observed max absolute errors remained at machine-precision scale

### Benchmark Summary

Benchmarks are documented in
[`benchmarks/benchmark_report_2026-03-27.md`](benchmarks/benchmark_report_2026-03-27.md).

Local Mac:

| Subset | Baseline Total | Improved First Run | Improved Cached Rerun | First-Run Speedup | Cached Speedup | Max Abs Error |
|---|---:|---:|---:|---:|---:|---:|
| `156461 x 128` | `0.578 s` | `0.157 s` | `0.108 s` | `3.67x` | `5.36x` | `1.90e-15` |
| `156461 x 256` | `1.295 s` | `0.261 s` | `0.132 s` | `4.96x` | `9.81x` | `2.28e-15` |

br200:

| Subset | Baseline Total | Improved First Run | Improved Cached Rerun | First-Run Speedup | Cached Speedup | Max Abs Error |
|---|---:|---:|---:|---:|---:|---:|
| `156461 x 128` | `7.079 s` | `1.078 s` | `0.392 s` | `6.56x` | `18.04x` | `1.76e-16` |
| `156461 x 256` | `14.393 s` | `1.581 s` | `0.623 s` | `9.10x` | `23.10x` | `2.57e-16` |

## Practical Impact

- avoids storing a large explicit `iA` matrix
- reduces reconstruction memory pressure
- makes repeated runs with the same keep mask and regularization parameters
  much faster
- provides a path that is more realistic to run on local hardware for large
  dense A-matrices

## Scope And Follow-Up

This PR does not replace the existing default reconstruction pipeline. It adds
an alternative exact path plus benchmarks.

Reasonable follow-up work after review:

- wire the cached path into the higher-level NeuroDOT pipeline or notebooks
- add unit tests around equivalence and keep-mask behavior
- optionally persist and reuse full measurement-space Gram caches when
  `lambda2 == 0`
